### PR TITLE
feat: add decimalSeparator prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ const App = () => {
 | `enterAnimationType` | no       | `'slide-in-up' or 'slide-in-down'` | Whether the new digit should enter from the top or the bottom                                                                                                                                                                                                                                                                          |
 | `separatorStyle`     | no       | `StyleProp<TextStyle>`             | Extra style applied only to separators. In this case, the colon (`:`) and the comma (`,`)                                                                                                                                                                                                                                              |
 | `textCharStyle`      | no       | `StyleProp<TextStyle>`             | The style applied to each individual character of the stopwatch/timer                                                                                                                                                                                                                                                                  |
+| `decimalSeparator` | no | `string` | Decimal separator for formatting time. Defaults to a comma `,` |
 
 ## Methods
 

--- a/src/StopwatchTimer.tsx
+++ b/src/StopwatchTimer.tsx
@@ -69,6 +69,10 @@ export interface StopwatchTimerProps {
    * If 1, the component will display seconds, minutes and hundredth of ms.
    */
   trailingZeros?: 0 | 1 | 2;
+  /**
+   * Decimal separator for formatting time. Defaults to a comma (','), but any string can be used for custom formats.
+   */
+  decimalSeparator?: string;
 }
 
 export interface StopwatchTimerMethods {
@@ -105,6 +109,7 @@ function Stopwatch(
     separatorStyle,
     textCharStyle,
     trailingZeros = 1,
+    decimalSeparator = ',',
   }: StopwatchTimerProps,
   ref: ForwardedRef<StopwatchTimerMethods>
 ) {
@@ -241,7 +246,7 @@ function Stopwatch(
               separatorStyle,
             ]}
           >
-            ,
+            {decimalSeparator}
           </Text>
           <Text
             style={[


### PR DESCRIPTION
This PR adds the option to specify which decimal separator is used for the milliseconds. It defaults to a comma `,`.